### PR TITLE
Add auto printing trigger on voting stop

### DIFF
--- a/cocon_vote_monitor/static/js/votes.js
+++ b/cocon_vote_monitor/static/js/votes.js
@@ -8,6 +8,8 @@ const footerEl = document.querySelector('footer');
 const yesCnt = document.querySelector('.vote.footer.yes  .vote-count');
 const abtCnt = document.querySelector('.vote.footer.abst .vote-count');
 const noCnt = document.querySelector('.vote.footer.no   .vote-count');
+const autoPrint = document.body.dataset.autoPrint === 'True';
+let printed = false;
 
 function buildColumns(columns = []) {
   const frag = document.createDocumentFragment();
@@ -43,6 +45,13 @@ function update(data) {
   abtCnt.textContent = data.counts?.ABST ?? 0;
   noCnt.textContent = data.counts?.NO ?? 0;
   footerEl.style.display = data.show_results ? 'flex' : 'none';
+  if (autoPrint && data.voting_state === 'Stop' && !printed) {
+    printed = true;
+    window.print();
+  }
+  if (data.voting_state !== 'Stop') {
+    printed = false;
+  }
 }
 
 const ws = new WebSocket(`ws://${location.host}/ws`);

--- a/cocon_vote_monitor/templates/index.html
+++ b/cocon_vote_monitor/templates/index.html
@@ -5,7 +5,7 @@
     <title>Voting Results</title>
       <link rel="stylesheet" href="/static/css/main.css">
   </head>
-  <body>
+  <body data-auto-print="{{ auto_print | default(False) }}">
     <header>
       <div class="header-left">
         <h1 id="meeting-title">Meeting Title</h1>


### PR DESCRIPTION
## Summary
- expose current voting state to clients
- trigger auto printing on `/autoprint` pages when the vote state is `Stop`

## Testing
- `python -m compileall -q cocon_vote_monitor`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a279b89ac832085ab9fba5e0da96d